### PR TITLE
Upgrade to Jruby-9.2.11 and Vertx-3.9.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Release 2.1.2
+=============
+* Upgrade to be compatible to JRuby 9.2.8.0
+
 Release 2.1.0
 =============
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Release 2.1.2
 =============
-* Upgrade to be compatible to JRuby 9.2.8.0
+* Upgrade to be compatible to JRuby 9.2.11.0
+* Vertx upgrade to 3.9.0
 
 Release 2.1.0
 =============

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
 source 'http://rubygems.org'
 
-gem 'rack', '>= 1.4.1'
+gem 'rack', '~> 1.4', '>= 1.4.1'
 #gem 'rack', path: "../../ruby/rack"
 gem 'spoon', '~> 0.0.4'
 
 group :development do
-  gem 'jeweler', '~> 1.8.7'
+  gem 'jeweler', '~> 1.8', '>= 1.8.7'
 end
 
 group :test do

--- a/jubilee.gemspec
+++ b/jubilee.gemspec
@@ -181,6 +181,8 @@ Gem::Specification.new do |s|
     "test/jubilee/test_upload.rb",
     "test/test_helper.rb"
   ]
+  s.files += Dir['jars/*']
+  s.files += Dir['lib/*.rb']
   s.homepage = "http://isaiah.github.io/jubilee"
   s.licenses = ["MIT"]
   s.rubygems_version = "2.4.8"

--- a/jubilee.gemspec
+++ b/jubilee.gemspec
@@ -6,7 +6,7 @@
 
 Gem::Specification.new do |s|
   s.name = "jubilee"
-  s.version = "3.0.0.beta2"
+  s.version = "3.0.1.beta1"
   s.platform = "java"
 
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
@@ -190,18 +190,18 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rack>, [">= 1.4.1"])
+      s.add_runtime_dependency 'rack', '~> 1.4', '>= 1.4.1'
       s.add_runtime_dependency(%q<spoon>, ["~> 0.0.4"])
-      s.add_development_dependency(%q<jeweler>, ["~> 1.8.7"])
+      s.add_development_dependency 'jeweler', '~> 1.8', '>= 1.8.7'
     else
-      s.add_dependency(%q<rack>, [">= 1.4.1"])
+      s.add_runtime_dependency 'rack', '~> 1.4', '>= 1.4.1'
       s.add_dependency(%q<spoon>, ["~> 0.0.4"])
-      s.add_dependency(%q<jeweler>, ["~> 1.8.7"])
+      s.add_development_dependency 'jeweler', '~> 1.8', '>= 1.8.7'
     end
   else
-    s.add_dependency(%q<rack>, [">= 1.4.1"])
+    s.add_runtime_dependency 'rack', '~> 1.4', '>= 1.4.1'
     s.add_dependency(%q<spoon>, ["~> 0.0.4"])
-    s.add_dependency(%q<jeweler>, ["~> 1.8.7"])
+    s.add_development_dependency 'jeweler', '~> 1.8', '>= 1.8.7'
   end
 end
 

--- a/jubilee.gemspec
+++ b/jubilee.gemspec
@@ -6,7 +6,7 @@
 
 Gem::Specification.new do |s|
   s.name = "jubilee"
-  s.version = "3.0.1.beta1"
+  s.version = "3.0.2"
   s.platform = "java"
 
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=

--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,10 @@
     <mods.directory>target/mods</mods.directory>
 
     <!--Dependency versions-->
-    <vertx.version>3.3.3</vertx.version>
+    <vertx.version>3.9.0</vertx.version>
     <vertx.testtools.version>2.0.3-final</vertx.testtools.version>
     <junit.version>4.12</junit.version>
+    <bugsnag.version>3.5.1</bugsnag.version>
 
     <!--Plugin versions-->
     <maven.compiler.plugin.version>3.0</maven.compiler.plugin.version>
@@ -106,7 +107,7 @@
     <dependency>
       <groupId>org.jruby</groupId>
       <artifactId>jruby-complete</artifactId>
-      <version>9.2.8.0</version>
+      <version>9.2.11.0</version>
       <scope>provided</scope>
     </dependency>
 
@@ -114,21 +115,21 @@
     <dependency>
         <groupId>com.bugsnag</groupId>
         <artifactId>bugsnag</artifactId>
-        <version>3.1.5</version>
+        <version>${bugsnag.version}</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/io.vertx/vertx-shell -->
     <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-shell</artifactId>
-        <version>3.5.1</version>
+        <version>${vertx.version}</version>
     </dependency>
 
     <!-- Used for deploying service:io.vertx.ext.shell -->
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-service-factory</artifactId>
-      <version>3.5.1</version>
+      <version>${vertx.version}</version>
     </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>org.jruby</groupId>
       <artifactId>jruby-complete</artifactId>
-      <version>9.1.2.0</version>
+      <version>9.2.8.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/main/java/org/jruby/jubilee/JubileeVerticle.java
+++ b/src/main/java/org/jruby/jubilee/JubileeVerticle.java
@@ -55,9 +55,11 @@ public class JubileeVerticle extends AbstractVerticle {
                 System.out.println("******** Vertx: 3");
                 BridgeOptions options = new BridgeOptions().addOutboundPermitted(new PermittedOptions().setAddressRegex(".+"));
                 options.addInboundPermitted(new PermittedOptions().setAddressRegex(".+"));
-                router.route("/" + config.getString("event_bus") + "/*").handler(SockJSHandler.create(vertx).bridge(options, event -> {
-                    event.complete(true);
-                }));
+                router.route("/" + config.getString("event_bus") + "/*").handler(routingHandler -> {
+                    SockJSHandler.create(vertx).bridge(options, event -> {
+                                        event.complete(true);
+                                    });
+                });
             }
             router.route("/*").handler(ctx -> {
                 // System.out.println("vertx_inside JubileeVerticle router..............."); 

--- a/src/main/java/org/jruby/jubilee/RackEnvironmentHash.java
+++ b/src/main/java/org/jruby/jubilee/RackEnvironmentHash.java
@@ -255,12 +255,6 @@ public class RackEnvironmentHash extends RubyHash {
     }
 
     @Override
-    public RubyFixnum hash19() {
-        fillEntireHash();
-        return super.hash19();
-    }
-
-    @Override
     public IRubyObject fetch(ThreadContext context, IRubyObject[] args, Block block) {
         fillEntireHash();
         return super.fetch(context, args, block);
@@ -330,18 +324,6 @@ public class RackEnvironmentHash extends RubyHash {
     public IRubyObject key(ThreadContext context, IRubyObject expected) {
         fillEntireHash();
         return super.key(context, expected);
-    }
-
-    @Override
-    public RubyArray keys() {
-        fillEntireHash();
-        return super.keys();
-    }
-
-    @Override
-    public RubyArray rb_values() {
-        fillEntireHash();
-        return super.rb_values();
     }
 
     @Override
@@ -462,18 +444,6 @@ public class RackEnvironmentHash extends RubyHash {
     public IRubyObject flatten(ThreadContext context, IRubyObject level) {
         fillEntireHash();
         return super.flatten(context, level);
-    }
-
-    @Override
-    public IRubyObject getCompareByIdentity(ThreadContext context) {
-        fillEntireHash();
-        return super.getCompareByIdentity(context);
-    }
-
-    @Override
-    public IRubyObject getCompareByIdentity_p(ThreadContext context) {
-        fillEntireHash();
-        return super.getCompareByIdentity_p(context);
     }
 
     @Override

--- a/src/main/java/org/jruby/jubilee/RubyNetSocket.java
+++ b/src/main/java/org/jruby/jubilee/RubyNetSocket.java
@@ -115,7 +115,7 @@ public class RubyNetSocket extends RubyObject {
             waitWritable(this.sock);
         this.sock.write(data.asJavaString());
         // TODO return the length actually written
-        return data.length();
+        return data;
     }
 
     @JRubyMethod(name = "close_write")

--- a/src/main/java/org/jruby/jubilee/RubyNetSocket.java
+++ b/src/main/java/org/jruby/jubilee/RubyNetSocket.java
@@ -3,7 +3,6 @@ package org.jruby.jubilee;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.vertx.core.Handler;
-import io.vertx.core.VoidHandler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.streams.WriteStream;
@@ -60,9 +59,9 @@ public class RubyNetSocket extends RubyObject {
             else sock.pause();
         });
 
-        this.sock.endHandler(new VoidHandler() {
+        this.sock.endHandler(new Handler<Void>() {
             @Override
-            protected void handle() {
+            public void handle(Void event) {
                 eof.set(true);
             }
         });


### PR DESCRIPTION
* involves expanding versions of required gems in Gemfile
* involves expanding versions of required gem dependencies in gemspec
* removal of override methods which are final in upgraded JRuby 9.8.2.0
* A change in the return object in RubyNetSocket